### PR TITLE
Add HTTPS support

### DIFF
--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -74,6 +74,8 @@
     <MicrosoftExtensionsCachingAbstractionsPackageVersion>2.1.0-preview1-27982</MicrosoftExtensionsCachingAbstractionsPackageVersion>
     <MicrosoftExtensionsCachingMemoryPackageVersion>2.1.0-preview1-27982</MicrosoftExtensionsCachingMemoryPackageVersion>
     <MicrosoftExtensionsCachingRedisPackageVersion>2.1.0-preview1-27982</MicrosoftExtensionsCachingRedisPackageVersion>
+    <MicrosoftIdentitiyModelClientsActiveDirectoryPackageVersion>3.19.1</MicrosoftIdentitiyModelClientsActiveDirectoryPackageVersion>
+    <MicrosoftAzureKeyVaultPackageVersion>2.3.2</MicrosoftAzureKeyVaultPackageVersion>
   </PropertyGroup>
   <Import Project="$(DotNetPackageVersionPropsPath)" Condition=" '$(DotNetPackageVersionPropsPath)' != '' " />
 </Project>

--- a/samples/ServiceSample/KeyVaultHelper.cs
+++ b/samples/ServiceSample/KeyVaultHelper.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Azure.KeyVault;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Clients.ActiveDirectory;
+using System;
+using System.Security.Cryptography.X509Certificates;
+
+namespace ServiceSample
+{
+    public static class KeyVaultHelper
+    {
+        public static X509Certificate2 GetKestrelCertificate(IConfiguration config)
+        {
+            var kvAuthCallback = CreateAuthCallback(config["Https:KeyVaultClientId"], config["Https:KeyVaultClientCertPath"]);
+            var kv = new KeyVaultClient(kvAuthCallback);
+            var sb = kv.GetSecretAsync(config["Https:KeyVaultCertUri"]).Result;
+            return new X509Certificate2(Convert.FromBase64String(sb.Value));
+        }
+
+        private static KeyVaultClient.AuthenticationCallback CreateAuthCallback(string clientId, string clientCertPath)
+        {
+            return async (string authority, string resource, string scope) =>
+            {
+                var authContext = new AuthenticationContext(authority);
+                var clientCert = new X509Certificate2(clientCertPath);
+                var credentials = new ClientAssertionCertificate(clientId, clientCert);
+                AuthenticationResult result = await authContext.AcquireTokenAsync(resource, credentials);
+
+                if (result == null)
+                    throw new InvalidOperationException("Failed to obtain the JWT token");
+
+                return result.AccessToken;
+            };
+        }
+    }
+}

--- a/samples/ServiceSample/Program.cs
+++ b/samples/ServiceSample/Program.cs
@@ -2,6 +2,9 @@
 using System.IO;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Configuration;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
+using System.Net;
 
 namespace ServiceSample
 {
@@ -12,8 +15,8 @@ namespace ServiceSample
             new WebHostBuilder()
                 .UseSetting(WebHostDefaults.PreventHostingStartupKey, "true")
                 .ConfigureLogging(LoggingConfig)
-                .UseKestrel()
-                .UseUrls("http://*:5001/", "http://*:5002/")
+                .ConfigureAppConfiguration(ConfigurationConfig)
+                .UseKestrel(KestrelConfig)
                 .UseContentRoot(Directory.GetCurrentDirectory())
                 .UseStartup<Startup>()
                 .Build()
@@ -26,6 +29,32 @@ namespace ServiceSample
                 builder.AddConfiguration(context.Configuration.GetSection("Logging"));
                 builder.AddConsole();
                 builder.AddDebug();
+            };
+
+        private static readonly Action<WebHostBuilderContext, IConfigurationBuilder> ConfigurationConfig =
+            (context, builder) =>
+            {
+                builder
+                    .SetBasePath(context.HostingEnvironment.ContentRootPath)
+                    .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
+                    .AddJsonFile($"appsettings.{context.HostingEnvironment.EnvironmentName}.json", optional: true)
+                    .AddEnvironmentVariables();
+            };
+
+        private static readonly Action<WebHostBuilderContext, KestrelServerOptions> KestrelConfig =
+            (context, options) =>
+            {
+                if ("true".Equals(context.Configuration["Https:Enabled"], StringComparison.OrdinalIgnoreCase))
+                {
+                    var cert = KeyVaultHelper.GetKestrelCertificate(context.Configuration);
+                    options.Listen(IPAddress.Any, 5001, listenOptions => listenOptions.UseHttps(cert));
+                    options.Listen(IPAddress.Any, 5002, listenOptions => listenOptions.UseHttps(cert));
+                }
+                else
+                {
+                    options.Listen(IPAddress.Any, 5001);
+                    options.Listen(IPAddress.Any, 5002);
+                }
             };
     }
 }

--- a/samples/ServiceSample/ServiceSample.csproj
+++ b/samples/ServiceSample/ServiceSample.csproj
@@ -15,6 +15,8 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="$(MicrosoftExtensionsLoggingConfigurationPackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="$(MicrosoftExtensionsLoggingConsolePackageVersion)" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="$(MicrosoftExtensionsLoggingDebugPackageVersion)" />
+    <PackageReference Include="Microsoft.IdentityModel.Clients.ActiveDirectory" Version="$(MicrosoftIdentitiyModelClientsActiveDirectoryPackageVersion)" />
+    <PackageReference Include="Microsoft.Azure.KeyVault" Version="$(MicrosoftAzureKeyVaultPackageVersion)" />
     <PackageReference Include="Newtonsoft.Json" Version="$(NewtonsoftJsonPackageVersion)" />
   </ItemGroup>
 

--- a/samples/ServiceSample/Startup.cs
+++ b/samples/ServiceSample/Startup.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Azure.SignalR;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -15,16 +14,13 @@ namespace ServiceSample
         public const string SecondarySigningKey = "Auth:JWT:IssuerSigningKey2";
         public const string RedisConnectionString = "Redis:ConnectionString";
 
-        public Startup(IHostingEnvironment env)
+        public Startup(IHostingEnvironment env, IConfiguration config)
         {
-            var builder = new ConfigurationBuilder()
-                .SetBasePath(env.ContentRootPath)
-                .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true)
-                .AddJsonFile($"appsettings.{env.EnvironmentName}.json", optional: true);
-
-            builder.AddEnvironmentVariables();
-            Configuration = builder.Build();
+            HostingEnvironment = env;
+            Configuration = config;
         }
+
+        public IHostingEnvironment HostingEnvironment { get; }
 
         public IConfiguration Configuration { get; }
 

--- a/samples/ServiceSample/appsettings.json
+++ b/samples/ServiceSample/appsettings.json
@@ -8,6 +8,12 @@
       "IssuerSigningKey2": "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ"
     }
   },
+  "Https": {
+    "Enabled": false,
+    "KeyVaultClientId": "",
+    "KeyVaultClientCertPath": "",
+    "KeyVaultCertUri": ""
+  },
   "Redis": {
     "ConnectionString": ""
   },


### PR DESCRIPTION
HTTPS certificate is kept in KeyVault and we use a service principal to
access it.

Also update configuration build process as recommended in ASP.Net Core 2.0:
https://joonasw.net/view/aspnet-core-2-configuration-changes